### PR TITLE
Allow renaming of class methods

### DIFF
--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -196,13 +196,9 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
   // Check convertibility
   if (not worker->check_convertibility(f)) return;
 
-  // Insert in the module function list. Unicity will be taken care of later by worker.
-  str_t py_name = f->getNameAsString();
-  if (auto rename = clu::get_annotation_value(f, "c2py_rename")) py_name = *rename;
-
   // store the function in the module_info or as method of a class if c2py_wrap_as_method is set
   if (not clu::has_annotation(f, "c2py_wrap_as_method"))
-    M.functions[py_name].push_back(fnt_info_t{f});
+    M.functions[worker->get_python_name(f)].push_back(fnt_info_t{f});
   else {
     if (f->param_size() == 0) {
       clu::emit_error(f, "A function tagged c2py_wrap_as_method must take at least 1 argument (self)");
@@ -210,7 +206,7 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
     }
     auto first_arg_type = as_CXXRecordDecl(f->getParamDecl(0)->getType());
     if (auto it = M.classes_ptr_to_info.find(first_arg_type); it != M.classes_ptr_to_info.end())
-      M.classes[it->second].second.methods[py_name].push_back(fnt_info_t{.ptr = f, .rewrite = false});
+      M.classes[it->second].second.methods[worker->get_python_name(f)].push_back(fnt_info_t{.ptr = f, .rewrite = false});
     else
       clu::emit_error(f->getParamDecl(0), "You request to wrap this function as a method, but the first argument is not a class being wrapped.");
   }

--- a/src/tools/clair-c2py/worker.cpp
+++ b/src/tools/clair-c2py/worker.cpp
@@ -81,6 +81,13 @@ bool worker_t::check_convertibility(clang::FunctionDecl const *f, bool test_retu
 }
 //--------------------------------------------------------
 
+str_t worker_t::get_python_name(clang::FunctionDecl const *f) const {
+  str_t py_name = f->getNameAsString();
+  if (auto rename = clu::get_annotation_value(f, "c2py_rename")) py_name = *rename;
+  return py_name;
+}
+//--------------------------------------------------------
+
 void worker_t::analyze_one_method(clang::FunctionDecl const *f, cls_info_t &cls_info, cls_ptr_t cls) {
 
   if (f->isDeleted()) return;
@@ -127,7 +134,7 @@ void worker_t::analyze_one_method(clang::FunctionDecl const *f, cls_info_t &cls_
   }
 
   // generic case
-  if (check_convertibility(m)) cls_info.methods[m->getNameAsString()].push_back({m});
+  if (check_convertibility(m)) cls_info.methods[get_python_name(m)].push_back({m});
 }
 
 // ---------     MAKE UNIQUE functions--------------

--- a/src/tools/clair-c2py/worker.cpp
+++ b/src/tools/clair-c2py/worker.cpp
@@ -81,9 +81,9 @@ bool worker_t::check_convertibility(clang::FunctionDecl const *f, bool test_retu
 }
 //--------------------------------------------------------
 
-str_t worker_t::get_python_name(clang::NamedDecl const *d) const {
+str_t worker_t::get_python_name(clang::FunctionDecl const *d) const {
   if (auto rename = clu::get_annotation_value(d, "c2py_rename")) return *rename;
-  else return util::camel_case(d->getNameAsString());
+  else return d->getNameAsString();
 }
 
 //--------------------------------------------------------

--- a/src/tools/clair-c2py/worker.hpp
+++ b/src/tools/clair-c2py/worker.hpp
@@ -45,8 +45,8 @@ struct worker_t {
   bool check_convertibility(clang::FunctionDecl const *f, bool test_return_type = true) const;
 
 
-  /// Get the Python name of a decl after taking into account possible renaming.
-  str_t get_python_name(clang::NamedDecl const *d) const;
+  /// Get the Python name of a FunctionDecl after taking into account possible renaming.
+  str_t get_python_name(clang::FunctionDecl const *d) const;
 
   private:
   void analyze_one_method(clang::FunctionDecl const *f, cls_info_t &cls_info, cls_ptr_t cls);

--- a/src/tools/clair-c2py/worker.hpp
+++ b/src/tools/clair-c2py/worker.hpp
@@ -44,6 +44,9 @@ struct worker_t {
   /// Check if the function parameters and return type are convertible
   bool check_convertibility(clang::FunctionDecl const *f, bool test_return_type = true) const;
 
+  /// Get the Python name of a function or method after taking into account possible renaming.
+  str_t get_python_name(clang::FunctionDecl const *f) const;
+
   private:
   void analyze_one_method(clang::FunctionDecl const *f, cls_info_t &cls_info, cls_ptr_t cls);
   void scan_class_elements(cls_info_t &cls_info, cls_ptr_t cls);


### PR DESCRIPTION
- add new method `get_python_name` to the worker class
  - checks if a given function declaration has a rename attribute and renames it if so
- use `get_python_name` for functions as well as class methods