### PR TITLE
Add two-pass approach to match AST

### DIFF
--- a/src/tools/clair-c2py/ast_consumer.cpp
+++ b/src/tools/clair-c2py/ast_consumer.cpp
@@ -116,7 +116,6 @@ void ast_consumer::HandleTranslationUnit(clang::ASTContext &ctx) {
   // ------- Match the AST in two passes
   // Pass 1: Match classes and enums first, so all classes are collected
   // before we process functions (which may reference these classes)
-  // Pass 2: Match functions after that all classes are known
   MatchFinder mf1, mf2;
   matcher<mtch::Cls> ma_cls{worker};
   matcher<mtch::Enum> ma_enum{worker};
@@ -124,14 +123,15 @@ void ast_consumer::HandleTranslationUnit(clang::ASTContext &ctx) {
 
   mf1.addMatcher(add_excludes(call_cls).bind("class"), &ma_cls);
   mf1.addMatcher(add_excludes(call_enum).bind("en"), &ma_enum);
-  mf2.addMatcher(add_excludes(call_fun).bind("func"), &ma_f);
   mf1.addMatcher(namespaceDecl(isExpansionInMainFile(), hasName("c2py_module"), //
                                 forEach(typeAliasDecl().bind("decl"))),
                   &ma_using);
   mf1.matchAST(ctx);
   if (ctx.getDiagnostics().hasErrorOccurred()) return;
 
+  // Pass 2: Match functions after that all classes are known
   matcher<mtch::Fnt> ma_f{worker};
+  mf2.addMatcher(add_excludes(call_fun).bind("func"), &ma_f);
   mf2.matchAST(ctx);
   if (ctx.getDiagnostics().hasErrorOccurred()) return;
 

--- a/src/tools/clair-c2py/ast_consumer.cpp
+++ b/src/tools/clair-c2py/ast_consumer.cpp
@@ -116,24 +116,23 @@ void ast_consumer::HandleTranslationUnit(clang::ASTContext &ctx) {
   // ------- Match the AST in two passes
   // Pass 1: Match classes and enums first, so all classes are collected
   // before we process functions (which may reference these classes)
-  MatchFinder mf_1;
+  // Pass 2: Match functions after that all classes are known
+  MatchFinder mf1, mf2;
   matcher<mtch::Cls> ma_cls{worker};
   matcher<mtch::Enum> ma_enum{worker};
   matcher<mtch::ModuleClsWrap> ma_using{worker};
 
-  mf_1.addMatcher(add_excludes(call_cls).bind("class"), &ma_cls);
-  mf_1.addMatcher(add_excludes(call_enum).bind("en"), &ma_enum);
-  mf_1.addMatcher(namespaceDecl(isExpansionInMainFile(), hasName("c2py_module"), //
+  mf1.addMatcher(add_excludes(call_cls).bind("class"), &ma_cls);
+  mf1.addMatcher(add_excludes(call_enum).bind("en"), &ma_enum);
+  mf2.addMatcher(add_excludes(call_fun).bind("func"), &ma_f);
+  mf1.addMatcher(namespaceDecl(isExpansionInMainFile(), hasName("c2py_module"), //
                                 forEach(typeAliasDecl().bind("decl"))),
                   &ma_using);
-  mf_1.matchAST(ctx);
+  mf1.matchAST(ctx);
   if (ctx.getDiagnostics().hasErrorOccurred()) return;
 
-  // Pass 2: Match functions now that all classes are known
-  MatchFinder mf_2;
   matcher<mtch::Fnt> ma_f{worker};
-  mf_2.addMatcher(add_excludes(call_fun).bind("func"), &ma_f);
-  mf_2.matchAST(ctx);
+  mf2.matchAST(ctx);
   if (ctx.getDiagnostics().hasErrorOccurred()) return;
 
   // -------- done ----------

--- a/src/tools/clair-c2py/ast_consumer.cpp
+++ b/src/tools/clair-c2py/ast_consumer.cpp
@@ -113,23 +113,27 @@ void ast_consumer::HandleTranslationUnit(clang::ASTContext &ctx) {
     return functionDecl(std::move(x)..., excludes);
   };
 
-  // ------- Match the AST
-  MatchFinder mf;
-
+  // ------- Match the AST in two passes
+  // Pass 1: Match classes and enums first, so all classes are collected
+  // before we process functions (which may reference these classes)
+  MatchFinder mf_1;
   matcher<mtch::Cls> ma_cls{worker};
   matcher<mtch::Enum> ma_enum{worker};
-  matcher<mtch::Fnt> ma_f{worker};
   matcher<mtch::ModuleClsWrap> ma_using{worker};
 
-  mf.addMatcher(add_excludes(call_cls).bind("class"), &ma_cls);
-  mf.addMatcher(add_excludes(call_enum).bind("en"), &ma_enum);
-  mf.addMatcher(add_excludes(call_fun).bind("func"), &ma_f);
+  mf_1.addMatcher(add_excludes(call_cls).bind("class"), &ma_cls);
+  mf_1.addMatcher(add_excludes(call_enum).bind("en"), &ma_enum);
+  mf_1.addMatcher(namespaceDecl(isExpansionInMainFile(), hasName("c2py_module"), //
+                                forEach(typeAliasDecl().bind("decl"))),
+                  &ma_using);
+  mf_1.matchAST(ctx);
+  if (ctx.getDiagnostics().hasErrorOccurred()) return;
 
-  mf.addMatcher(namespaceDecl(isExpansionInMainFile(), hasName("c2py_module"), //
-                              forEach(typeAliasDecl().bind("decl"))),
-                &ma_using);
-
-  mf.matchAST(ctx);
+  // Pass 2: Match functions now that all classes are known
+  MatchFinder mf_2;
+  matcher<mtch::Fnt> ma_f{worker};
+  mf_2.addMatcher(add_excludes(call_fun).bind("func"), &ma_f);
+  mf_2.matchAST(ctx);
   if (ctx.getDiagnostics().hasErrorOccurred()) return;
 
   // -------- done ----------


### PR DESCRIPTION
- first match classes/enums to detect all wrapped types
- then match functions which may rely on wrapped types