### PR TITLE
Allow friend functions to be wrapped

### DIFF
--- a/src/tools/clair-c2py/ast_consumer.cpp
+++ b/src/tools/clair-c2py/ast_consumer.cpp
@@ -103,7 +103,9 @@ void ast_consumer::HandleTranslationUnit(clang::ASTContext &ctx) {
       return add_match_files(l);
   };
   // Final call of the chain, for classes, enums and functions
-  // Function are special, as we have to exclude methods and friend declarations
+  // Functions are special: exclude methods. Friend declarations (both inline
+  // definitions and out-of-class declarations) are matched; deduplication
+  // against out-of-class definitions is handled in the Fnt matcher callback.
   auto call_cls = [&](auto... x) {
     return cxxRecordDecl(std::move(x)...); //excludes);
   };
@@ -111,8 +113,7 @@ void ast_consumer::HandleTranslationUnit(clang::ASTContext &ctx) {
     return enumDecl(std::move(x)...); //excludes);
   };
   auto call_fun = [&](auto... x) {
-    auto excludes = unless(anyOf(cxxMethodDecl(), hasAncestor(friendDecl())));
-    return functionDecl(std::move(x)..., excludes);
+    return functionDecl(std::move(x)..., unless(cxxMethodDecl()));
   };
 
   // ------- Match the AST in two passes

--- a/src/tools/clair-c2py/codegen/fnt.cpp
+++ b/src/tools/clair-c2py/codegen/fnt.cpp
@@ -69,10 +69,14 @@ void codegen::write_dispatch(std::ostream &code, std::ostream &table, std::ostre
   auto parent_cls_name = (not cls_alias.empty()) ? cls_alias : (parent_class ? clu::get_fully_qualified_name(parent_class) : str_t{});
 
   auto l = [&enforce_method, parent_class, &parent_cls_name](fnt_info_t const &f_info) {
-    auto *f        = f_info.ptr;
-    auto *m        = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(f);
-    auto args      = fnt_params_with_default(f);
-    auto fname     = (m and parent_class ? parent_cls_name + "::" + f->getNameAsString() : f->getQualifiedNameAsString());
+    auto *f   = f_info.ptr;
+    auto *m   = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(f);
+    auto args = fnt_params_with_default(f);
+    // Inline friend functions (defined inside a class body) are only found via ADL,
+    // so they must be called unqualified. They are not CXXMethodDecls.
+    bool is_inline_friend = (not m) and f->getFriendObjectKind() != clang::Decl::FOK_None;
+    auto fname            = (m and parent_class ? parent_cls_name + "::" + f->getNameAsString() :
+                                                  (is_inline_friend ? f->getNameAsString() : f->getQualifiedNameAsString()));
     auto fname_log = (m and parent_class ? clu::get_fully_qualified_name(parent_class) + "::" + f->getNameAsString() : f->getQualifiedNameAsString());
 
     auto cfun_or_cmethod = std::string{enforce_method and (not m) ? "cmethod" : "cfun"};

--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -189,6 +189,13 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
   // method should not be here
   EXPECTS(not llvm::isa<clang::CXXMethodDecl>(f));
 
+  // Deduplicate friend declarations vs out-of-class definitions.
+  // If this is a friend declaration (not a definition) and the definition
+  // exists in this TU, skip — the definition will be matched separately.
+  // If no definition is visible (defined in another .cpp), keep the declaration.
+  if (f->getFriendObjectKind() != clang::Decl::FOK_None and not f->isThisDeclarationADefinition())
+    if (f->getDefinition()) return;
+
   if (f->getQualifiedNameAsString().starts_with("c2py::")) {
     logs.error("FATAL ERROR: incorrect configuration or includes. It requests wrapping c2py functions which makes no sense.");
     std::abort();

--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -205,6 +205,9 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
   auto &M = wdata->module_info;
   if (should_reject(f, wdata->reject_names, &logs.rejected)) return;
 
+  // h5_write/h5_read are HDF5 serialization helpers, never meant to be wrapped
+  if (auto name = f->getNameAsString(); name == "h5_write" || name == "h5_read") return;
+
   // Special treatment for operator
   if (f->getNameAsString().starts_with("operator")) {
     analyze_operator(f, *wdata);

--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -201,8 +201,9 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
   if (f->getFriendObjectKind() != clang::Decl::FOK_None and not f->isThisDeclarationADefinition())
     if (f->getDefinition()) return;
 
+  // Wrapping c2py functions makes no sense, and is probably a mistake in the configuration or includes. Panic...
   if (f->getQualifiedNameAsString().starts_with("c2py::")) {
-    logs.error("FATAL ERROR: incorrect configuration or includes. It requests wrapping c2py functions which makes no sense.");
+    logs.error("FATAL ERROR: incorrect configuration or includes. It requests wrapping c2py functions, which makes no sense.");
     std::abort();
   }
 
@@ -210,8 +211,13 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
   auto &M = wdata->module_info;
   if (should_reject(f, wdata->reject_names, &logs.rejected)) return;
 
-  // h5_write/h5_read are HDF5 serialization helpers, never meant to be wrapped
-  if (auto name = f->getNameAsString(); name == "h5_write" || name == "h5_read") return;
+  // h5_write/h5_read/h5_read_construct  are HDF5 serialization helpers, never meant to be wrapped
+  // if we use the h5 method.
+  if (wdata->concepts.HasHdf5)
+    if (auto name = f->getName(); name == "h5_write" || name == "h5_read" || name == "h5_read_construct") {
+      logs.rejected(fmt::format(R"RAW({0} [treated directly in h5 support])RAW", name));
+      return;
+    }
 
   // Special treatment for operator
   if (f->getNameAsString().starts_with("operator")) {

--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -186,6 +186,11 @@ template <> void matcher<mtch::Fnt>::run(const MatchResult &Result) {
   // Reject function template declaration
   if (f->getDescribedFunctionTemplate()) return;
 
+  // Reject functions with dependent (unresolved) types.
+  // This filters out the pattern FunctionDecl of friend functions defined inside 
+  // class templates whose types still contain template parameters like `type-parameter-0-0`.
+  if (f->getType()->isDependentType()) return;
+
   // method should not be here
   EXPECTS(not llvm::isa<clang::CXXMethodDecl>(f));
 

--- a/src/tools/clair-c2py/scan_classes.cpp
+++ b/src/tools/clair-c2py/scan_classes.cpp
@@ -56,7 +56,7 @@ static void analyze_one_method(clang::FunctionDecl const *f, cls_info_t &cls_inf
   auto name = m->getNameAsString();
 
   // hdf5_format is an HDF5 serialization helper, never meant to be wrapped
-  if (name == "hdf5_format") return;
+  if (wd.concepts.HasHdf5 and name == "hdf5_format") return;
 
   // ---- constructors
   if (llvm::isa<clang::CXXConstructorDecl>(m)) {

--- a/src/tools/clair-c2py/scan_classes.cpp
+++ b/src/tools/clair-c2py/scan_classes.cpp
@@ -55,6 +55,9 @@ static void analyze_one_method(clang::FunctionDecl const *f, cls_info_t &cls_inf
 
   auto name = m->getNameAsString();
 
+  // hdf5_format is an HDF5 serialization helper, never meant to be wrapped
+  if (name == "hdf5_format") return;
+
   // ---- constructors
   if (llvm::isa<clang::CXXConstructorDecl>(m)) {
     const bool is_base_class = (cls != cls_info.ptr);

--- a/src/utility/logger.hpp
+++ b/src/utility/logger.hpp
@@ -5,8 +5,15 @@
 #include <utility>
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <llvm/ADT/StringRef.h>
 
 #include "string_tools.hpp"
+
+template <> struct fmt::formatter<llvm::StringRef> : fmt::formatter<std::string_view> {
+  auto format(llvm::StringRef s, fmt::format_context &ctx) const {
+    return fmt::formatter<std::string_view>::format({s.data(), s.size()}, ctx);
+  }
+};
 
 namespace util {
   class logger {


### PR DESCRIPTION
- allow in-class as well as out-of-class friends
- in-class friends are called with their unqualified function name
- filter friends in the matcher to avoid duplication (declaration vs. definition)
- exclude `h5_write`, `h5_read` and `hdf5_format` 