### PR TITLE
Fix issue with llvm 22

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -36,9 +36,10 @@ The ``clair_c2py`` tool automatizes this task
 
 It outputs/updates the following files:
 
-* ``getting_started.wrap.cxx`` contains the generated bindings (based on **c2py**) which have to be compiled together with the 
+* ``getting_started.wrap.cxx`` contains the generated bindings (based on **c2py**) which have to be compiled together with the
   original C++ code.
 * ``getting_started.wrap.hxx`` contains some additional information (only needed when working with :ref:`multiple_modules`).
+  It is only generated if the module wraps at least one class (there is no useful content otherwise).
 * ``getting_started.cpp`` is updated to ``#include`` the file ``getting_started.wrap.cxx``.
 
 After the bindings have been generated, the only thing left to do is to compile ``getting_started.cpp`` into a Python module.

--- a/doc/getting_started/use_clair_c2py_manually.rst
+++ b/doc/getting_started/use_clair_c2py_manually.rst
@@ -21,8 +21,10 @@ Generate Python Bindings
    
    clair-c2py getting_started.cpp -- -std=c++20 `c2py_flags -i`
 
-This generates the C++/Python binding files ``getting_started.wrap.cxx`` and ``getting_started.wrap.hxx``, and updates the 
-original source file ``getting_started.cpp`` to include the generated bindings. 
+This generates the C++/Python binding file ``getting_started.wrap.cxx`` and updates the
+original source file ``getting_started.cpp`` to include the generated bindings.
+A companion header ``getting_started.wrap.hxx`` is also generated when the module wraps at least one class
+(see :ref:`multiple_modules`).
 
 See :ref:`generate_python_bindings_and_compile` for some more background information.
 

--- a/doc/reference/multiple.rst
+++ b/doc/reference/multiple.rst
@@ -5,14 +5,17 @@ Across multiple modules
 
 When developing larger projects, you may need to create multiple C++ Python extension modules that communicate with each other. For example, module B might need to use a class defined and wrapped in module A.
 
-``clair-c2py`` generates two files for each wrapped module:
+``clair-c2py`` generates up to two files for each wrapped module:
 
-- A ``.wrap.cxx`` file (the implementation of the bindings)
-- A ``.wrap.hxx`` file (a small header declaring which classes are wrapped in A)
+- A ``.wrap.cxx`` file (the implementation of the bindings), always generated.
+- A ``.wrap.hxx`` file (a small header declaring which classes are wrapped in A),
+  generated only if module A wraps at least one class.
 
 The ``.wrap.hxx`` file allows other modules to know the type wrapped in module A.
 Technically, it just specializes of the
 ``c2py::is_wrapped<T>`` variable for each type ``T`` wrapped in module A.
+Modules that wrap only free functions and/or enums do not produce a ``.wrap.hxx``,
+since there is no per-class information to share.
 
 Example: Two communicating modules
 ===================================

--- a/src/tools/clair-c2py/codegen/module.cpp
+++ b/src/tools/clair-c2py/codegen/module.cpp
@@ -121,6 +121,9 @@ str_t codegen_wrap_info(module_info_t const &m) {
 // =========== hxx generation ==============
 
 str_t codegen_hxx(module_info_t const &m) {
+  auto wrap_info = codegen_wrap_info(m);
+  if (wrap_info.empty()) return {};
+
   std::stringstream hxx;
   hxx << "#include <c2py/c2py.hpp>\n\n";
   hxx << fmt::format(R"RAW(
@@ -128,7 +131,7 @@ str_t codegen_hxx(module_info_t const &m) {
     #define C2PY_HXX_DECLARATION_{0}_GUARDS
     )RAW",
                      m.module_name);
-  hxx << codegen_wrap_info(m);
+  hxx << wrap_info;
   hxx << "\n#endif";
 
   return hxx.str();

--- a/src/tools/clair-c2py/custom_action.cpp
+++ b/src/tools/clair-c2py/custom_action.cpp
@@ -64,7 +64,8 @@ void custom_action::EndSourceFileAction() {
 
   log(fmt::format("\033[1;34m[Success] \033[0m"));
   log(fmt::format("   Generated Python bindings: {} [included in {}]", outfilename, wdata->module_info.sourcefile));
-  log(fmt::format("             headers        : {} [to be used with other modules, cf doc]", outfilename_hxx));
+  if (not code_hxx.empty())
+    log(fmt::format("             headers        : {} [to be used with other modules, cf doc]", outfilename_hxx));
 
   if (not std::getenv("CLAIR_SKIP_CLANG_FORMAT")) {
     log("Running clang-format ...");
@@ -74,13 +75,13 @@ void custom_action::EndSourceFileAction() {
                                                       )
                                  .get(); // because of FallBack the get is always valid
 
-    code     = clu::clang_format(code, clang_format_style);
-    code_hxx = clu::clang_format(code_hxx, clang_format_style);
+    code = clu::clang_format(code, clang_format_style);
+    if (not code_hxx.empty()) code_hxx = clu::clang_format(code_hxx, clang_format_style);
     log("Done.");
   }
 
   std::ofstream(outfilename) << code;
-  std::ofstream(outfilename_hxx) << code_hxx;
+  if (not code_hxx.empty()) std::ofstream(outfilename_hxx) << code_hxx;
 
   // Examine if the preprocessor has found the include of the generated file in the module.
   if (not wdata->input_has_included_generated_cxx) {

--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -139,7 +139,7 @@ template <> void matcher<mtch::Cls>::run(const clang::ast_matchers::MatchFinder:
 static clang::CXXRecordDecl *as_CXXRecordDecl(clang::QualType qtype) {
   qtype = qtype.getNonReferenceType().getCanonicalType();
   if (auto *rtype = qtype->getAs<clang::RecordType>())
-    if (auto *cxxrec = llvm::dyn_cast<clang::CXXRecordDecl>(rtype->getDecl())) return cxxrec;
+    if (auto *cxxrec = llvm::dyn_cast<clang::CXXRecordDecl>(rtype->getDecl())) return cxxrec->getCanonicalDecl();
   return nullptr; // Not a class/struct type
 }
 

--- a/src/tools/clair-c2py/wdata.cpp
+++ b/src/tools/clair-c2py/wdata.cpp
@@ -41,9 +41,10 @@ std::vector<fnt_info_t> make_unique_decls(std::vector<fnt_info_t> const &flist) 
 // ------------------------------
 
 void module_info_t::add_class(std::string_view name, clang::CXXRecordDecl const *cls) {
-  if (classes_ptr_to_info.contains(cls)) return; // already registered
+  auto *key = cls->getCanonicalDecl();
+  if (classes_ptr_to_info.contains(key)) return; // already registered
   classes.emplace_back(name, cls_info_t{.ptr = cls});
-  classes_ptr_to_info[cls] = long(classes.size() - 1);
+  classes_ptr_to_info[key] = long(classes.size() - 1);
 }
 
 // ------------------------------
@@ -51,6 +52,7 @@ void module_info_t::add_class(std::string_view name, clang::CXXRecordDecl const 
 cls_ptr_t module_info_t::get_wrapped_cls(clang::QualType ty) const {
   clang::CXXRecordDecl const *cls = ty->getAsCXXRecordDecl();
   if (!cls) cls = ty->getPointeeCXXRecordDecl();
+  if (cls) cls = cls->getCanonicalDecl();
   return (cls and classes_ptr_to_info.contains(cls)) ? cls : nullptr;
 }
 


### PR DESCRIPTION
For certain function template instantiations, wrapped types are not found because of pointer mismatches in the class map.

The issue came up when I tried to wrap functions taking a TRIQS mesh as an argument. For example, the [triqs::mesh::values](https://github.com/TRIQS/triqs/blob/unstable/c%2B%2B/triqs/mesh/utils.hpp#L94-L98) function with the following template instantiation
```cpp
template C2PY_WRAP_AS_METHOD auto values(imfreq const &);
```
triggered [this error](https://github.com/flatironinstitute/clair/blob/unstable/src/tools/clair-c2py/matchers.cpp#L158) in clair.

I tried to mimic the behavior in tests but without any success.