### PR TITLE
[clair-c2py] Emit tp_hash specialization for Hashable classes

### DIFF
--- a/src/tools/clair-c2py/codegen/classes.cpp
+++ b/src/tools/clair-c2py/codegen/classes.cpp
@@ -305,6 +305,10 @@ str_t codegen_cls(std::ostream &code, str_t const &cls_py_name, cls_info_t const
   // -- tp_name
   code << '\n' << fmt::format(R"RAW(template <> inline constexpr auto c2py::tp_name<{0}> = "{1}.{2}";)RAW", cls_alias, full_module_name, cls_py_name);
 
+  // -- tp_hash: wire Python __hash__ to c2py::tp_hash_impl (dispatches to std::hash<T>)
+  if (cls_info.has_hash)
+    code << '\n' << fmt::format(R"RAW(template <> constexpr hashfunc c2py::tp_hash<{0}> = c2py::tp_hash_impl<{0}>;)RAW", cls_alias);
+
   // ---------- Methods ------------
   {
     std::stringstream MethodDecls, MethodTable, MethodDocs;

--- a/src/tools/clair-c2py/matchers.cpp
+++ b/src/tools/clair-c2py/matchers.cpp
@@ -46,6 +46,8 @@ template <> void matcher<mtch::Concept>::run(const MatchResult &Result) {
       wdata->concepts.HasNonDeletedDefaultConstructor = {cpt, wdata->ci};
     else if (cname == "Storable")
       wdata->concepts.HasHdf5 = {cpt, wdata->ci};
+    else if (cname == "Hashable")
+      wdata->concepts.Hashable = {cpt, wdata->ci};
     // else ignore the others concepts
   }
 }

--- a/src/tools/clair-c2py/scan_classes.cpp
+++ b/src/tools/clair-c2py/scan_classes.cpp
@@ -154,6 +154,9 @@ static void scan_class(wdata_t &wd, cls_info_t &cls_info) {
   // h5
   cls_info.has_hdf5 = wd.concepts.HasHdf5.is_satisfied_by(cls_info.ptr);
 
+  // hash: Python __hash__ support via std::hash<T>
+  cls_info.has_hash = wd.concepts.Hashable.is_satisfied_by(cls_info.ptr);
+
   // Serialization
   if (wd.concepts.HasSerializeLikeBoost.is_satisfied_by(cls_info.ptr))
     cls_info.serialization = Serialization::Tuple;

--- a/src/tools/clair-c2py/wdata.hpp
+++ b/src/tools/clair-c2py/wdata.hpp
@@ -49,6 +49,7 @@ struct cls_info_t {
   bool has_size_method                             = false;
   bool has_iterator                                = false;
   bool has_hdf5                                    = false;
+  bool has_hash                                    = false;
   Serialization serialization                      = Serialization::None;
 
   struct property {
@@ -112,6 +113,7 @@ struct wdata_t {
     clu::concept_holder HasSerializeLikeBoost;
     clu::concept_holder HasHdf5;
     clu::concept_holder HasNonDeletedDefaultConstructor;
+    clu::concept_holder Hashable;
   } concepts;
 
   // Preprocessor will detect if the input has included the generated cxx file


### PR DESCRIPTION
## Summary

Wires up the Python `__hash__` opt-in path added in [c2py#20](https://github.com/flatironinstitute/c2py/pull/20): detect classes satisfying `c2py::concepts::Hashable` and emit

```cpp
template <> constexpr hashfunc c2py::tp_hash<Cls> = c2py::tp_hash_impl<Cls>;
```

alongside the existing `tp_name` / `is_wrapped` block. Mirrors the `HasHdf5` detection/emission pattern end-to-end (`matchers.cpp`, `wdata.hpp`, `scan_classes.cpp`, `codegen/classes.cpp`). Wrapped types without `std::hash<T>` produce no emission and stay unhashable as before.

Depends on c2py#20 — without it, the emitted `c2py::tp_hash<T>` specialization would not compile.

## Test plan

- [x] Build clair against the c2py `hashable-concept` branch.
- [x] Regenerate a wrap file for a class with `std::hash<T>` and confirm the expected `template <> constexpr hashfunc c2py::tp_hash<...>` line appears.
- [x] Regenerate a wrap file for a class without `std::hash<T>` and confirm no `tp_hash` emission.
- [x] Downstream triqs `test_copy_pickle` + `test_canonical_ops_hashable` pass once the chain (c2py -> clair -> triqs regenerate) is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)