### PR TITLE
Support LLVM/Clang 23 and test LLVM 21-23 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@v6
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ matrix.os }}-${{ matrix.cc || matrix.llvm }}-${{ github.run_id }}
@@ -128,7 +128,7 @@ jobs:
       if: always()
       run: ccache -sv
 
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v6
       if: always()
       with:
         path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           - {os: ubuntu-24.04, llvm: 21, doc: OFF, apt_llvm_org: true }
           - {os: ubuntu-24.04, llvm: 22, doc: OFF, apt_llvm_org: true }
           - {os: ubuntu-24.04, llvm: 23, doc: OFF, apt_llvm_org: true }
-          - {os: macos-14, cc: clang, cxx: clang++, doc: OFF }
+          - {os: macos-26, cc: clang, cxx: clang++, doc: OFF }
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-24.04, cc: clang-20, cxx: clang++-20, doc: ON }
+          # ubuntu builds with the versioned clang packages of matrix.llvm, macos with the unversioned clang of brew's llvm
+          - {os: ubuntu-24.04, llvm: 20, doc: ON }
+          - {os: ubuntu-24.04, llvm: 21, doc: OFF, apt_llvm_org: true }
+          - {os: ubuntu-24.04, llvm: 22, doc: OFF, apt_llvm_org: true }
+          - {os: ubuntu-24.04, llvm: 23, doc: OFF, apt_llvm_org: true }
           - {os: macos-14, cc: clang, cxx: clang++, doc: OFF }
 
     runs-on: ${{ matrix.os }}
@@ -37,9 +41,20 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: ccache-${{ matrix.os }}-${{ matrix.cc }}-${{ github.run_id }}
+        key: ccache-${{ matrix.os }}-${{ matrix.cc || matrix.llvm }}-${{ github.run_id }}
         restore-keys:
-          ccache-${{ matrix.os }}-${{ matrix.cc }}-
+          ccache-${{ matrix.os }}-${{ matrix.cc || matrix.llvm }}-
+
+    # LLVM releases newer than the one in the ubuntu repositories (currently 20) come from apt.llvm.org.
+    # The versioned suite is used rather than llvm.sh, whose unversioned "development" suite moves on to
+    # the next major version as soon as LLVM branches for release.
+    - name: Add the apt.llvm.org repository
+      if: ${{ matrix.apt_llvm_org }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y lsb-release wget software-properties-common gnupg
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+        sudo add-apt-repository -y "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ matrix.llvm }} main"
 
     - name: Install ubuntu dependencies
       if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -48,13 +63,13 @@ jobs:
         sudo apt-get install lsb-release wget software-properties-common &&
         sudo apt-get install
         ccache
-        clang-20
+        clang-${{ matrix.llvm }}
         g++
         doxygen
-        llvm-20-dev
-        libclang-20-dev
+        llvm-${{ matrix.llvm }}-dev
+        libclang-${{ matrix.llvm }}-dev
         libomp-dev
-        clang-format-20
+        clang-format-${{ matrix.llvm }}
         libgmp-dev
         libhdf5-dev
         libopenblas-dev
@@ -98,8 +113,8 @@ jobs:
 
     - name: Build clair
       env:
-        CC: ${{ matrix.cc }}
-        CXX: ${{ matrix.cxx }}
+        CC: ${{ matrix.cc || format('clang-{0}', matrix.llvm) }}
+        CXX: ${{ matrix.cxx || format('clang++-{0}', matrix.llvm) }}
       run: |
         cmake -B build -S. -DCMAKE_INSTALL_PREFIX=$HOME/install -DBuild_Documentation=${{ matrix.doc }}
         cd build && make -j2 || make -j1 VERBOSE=1
@@ -117,7 +132,7 @@ jobs:
       if: always()
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: ccache-${{ matrix.os }}-${{ matrix.cc }}-${{ github.run_id }}
+        key: ccache-${{ matrix.os }}-${{ matrix.cc || matrix.llvm }}-${{ github.run_id }}
 
     - name: Deploy unstable documentation to website
       if: matrix.doc == 'ON' && github.ref == 'refs/heads/unstable'

--- a/src/clu/doc_string.cpp
+++ b/src/clu/doc_string.cpp
@@ -60,7 +60,13 @@ namespace clu {
 
   str_t get_raw_comment(const clang::Decl *d) {
     auto &ctx = d->getASTContext();
-    if (const clang::RawComment *rc = ctx.getRawCommentForDeclNoCache(d)) {
+#if LLVM_VERSION_MAJOR >= 23
+    // getRawCommentForDeclNoCache was generalized to macros and renamed (llvm/llvm-project#198452)
+    const clang::RawComment *rc = ctx.getRawCommentNoCache(d);
+#else
+    const clang::RawComment *rc = ctx.getRawCommentForDeclNoCache(d);
+#endif
+    if (rc) {
       return str_t{rc->getRawText(ctx.getSourceManager())};
     } else
       return {}; // no comment is not an error

--- a/src/clu/inject_bool_vartempl_specialization.cpp
+++ b/src/clu/inject_bool_vartempl_specialization.cpp
@@ -15,6 +15,13 @@ clang::VarTemplateSpecializationDecl *clu::inject_bool_vartempl_specialization(c
   Spec->setConstexpr(true);                                      // mirrors the template's 'static constexpr bool'; required for concept evaluation
   Spec->setInit(new (Ctx) clang::CXXBoolLiteralExpr(Value, Ctx.BoolTy, clang::SourceLocation())); // NOLINT  set to true
   Spec->setTemplateSpecializationKind(clang::TSK_ExplicitSpecialization); // treat as user-written template<> constexpr bool is_wrapped<T> = true
+  // An explicit specialization must also carry its argument list "as written": RecursiveASTVisitor
+  // dereferences getTemplateArgsAsWritten() unconditionally for TSK_ExplicitSpecialization since
+  // LLVM 23 (llvm/llvm-project#199131), so leaving it null segfaults every AST matcher traversal.
+  clang::SourceLocation Loc = VTD->getLocation();                // stands in for the angle-bracket and argument locations of the synthesized <T>
+  clang::TemplateArgumentListInfo ArgsAsWritten(Loc, Loc);
+  ArgsAsWritten.addArgument(clang::TemplateArgumentLoc(Arg, Ctx.getTrivialTypeSourceInfo(T, Loc)));
+  Spec->setTemplateArgsAsWritten(ArgsAsWritten);
   VTD->AddSpecialization(Spec, InsertPos);                       // register in the template's hash table at the position found above
   VTD->getDeclContext()->addDecl(Spec);                          // make visible in the c2py namespace for subsequent AST lookups
   return Spec;

--- a/src/tools/clair-c2py/custom_action.cpp
+++ b/src/tools/clair-c2py/custom_action.cpp
@@ -28,7 +28,14 @@ bool custom_action::BeginInvocation(clang::CompilerInstance &CI) {
 
   // Force color diagnostics if requested via environment variables
   // This ensures colors work even when output is redirected to a pipe
-  if (std::getenv("CLICOLOR_FORCE") || std::getenv("LLVM_FORCE_COLOR")) { CI.getDiagnosticOpts().ShowColors = true; }
+  if (std::getenv("CLICOLOR_FORCE") || std::getenv("LLVM_FORCE_COLOR")) {
+#if LLVM_VERSION_MAJOR >= 23
+    // ShowColors became a tri-state enum option with accessors (llvm/llvm-project#202441)
+    CI.getDiagnosticOpts().setShowColors(clang::ShowColorsKind::On);
+#else
+    CI.getDiagnosticOpts().ShowColors = true;
+#endif
+  }
 
   return true;
 }


### PR DESCRIPTION
Adds LLVM/Clang 23 support and extends the CI matrix to LLVM 21, 22 and 23.

**LLVM 23 API changes**

- `doc_string`: `getRawCommentForDeclNoCache` was generalized to macros and renamed `getRawCommentNoCache` (llvm/llvm-project#198452).
- `custom_action`: `DiagnosticOptions::ShowColors` is now a protected tri-state option set via `setShowColors` (llvm/llvm-project#202441).
- `inject_bool_vartempl_specialization`: the synthesized `is_wrapped<T>` specialization now carries its template argument list as written. llvm/llvm-project#199131 made that dereference unconditional, so the missing list segfaulted every matcher traversal.

The guards keep the LLVM >= 20 support range intact.

**CI matrix**

Ubuntu 24.04 only ships `clang-20`, so LLVM 21-23 come from the versioned `apt.llvm.org` suites rather than `llvm.sh`, whose unversioned suite stops providing `clang-23` once LLVM branches for release. The compiler is derived from a single `matrix.llvm` key so a bump cannot install one version's packages while compiling with another.

Built and tested in `ubuntu:24.04` containers: LLVM 21 and 22 pass 44/44, LLVM 23 passes 38/38 (against an older c2py). `noble-23` carries daily `release/23.x` snapshots, so that job can fail on a bad snapshot; `fail-fast: false` keeps it isolated.
